### PR TITLE
Fix offsetWidth console error

### DIFF
--- a/src/GridLayout.vue
+++ b/src/GridLayout.vue
@@ -197,7 +197,7 @@
                 };
             },
             onWindowResize: function () {
-                if (this.$refs !== null && this.$refs.item !== null) {
+                if (this.$refs !== null && this.$refs.item !== null && this.$refs.item !== undefined) {
                     this.width = this.$refs.item.offsetWidth;
                 }
             },


### PR DESCRIPTION
Under a really strange set of circumstances which I'll include below, the item is undefined so the condition proceeds but then gives a console error when trying to get the offset width.

1. Use Vue router
2. Manage the widgets on a dashboard
3. Move to another page and resize the window