### PR TITLE
fix bug

### DIFF
--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -251,6 +251,8 @@
             this.rtl = (direction == "rtl");
         },
         beforeDestroy: function(){
+            var self = this;
+
             //Remove listeners
             this.eventBus.$off('updateWidth', self.updateWidthHandler);
             this.eventBus.$off('compact', self.compactHandler);


### PR DESCRIPTION
When I delete a GridItem, the rest of the GridItem may be problematic, because the `self` here does not point to itself