### PR TITLE
Changed validateLayout in utils.js

### DIFF
--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -67,7 +67,7 @@
     }
 </style>
 <script>
-    import {setTopLeft, setTopRight, setTransformRtl, setTransform, createMarkup, getLayoutItem} from './utils';
+    import {setTopLeft, setTopRight, setTransformRtl, setTransform, createMarkup, getLayoutItem, validateLayout} from './utils';
     import {getControlPosition, offsetXYFromParentOf, createCoreData} from './draggableUtils';
 //    var eventBus = require('./eventBus');
 
@@ -262,6 +262,7 @@
             this.eventBus.$off('directionchange', self.directionchangeHandler);
         },
         mounted: function() {
+		    validateLayout(this);
             this.cols = this.$parent.colNum;
             this.rowHeight = this.$parent.rowHeight;
             this.containerWidth = this.$parent.width !== null ? this.$parent.width : 100;

--- a/src/GridLayout.vue
+++ b/src/GridLayout.vue
@@ -20,7 +20,7 @@
     import Vue from 'vue';
     var elementResizeDetectorMaker = require("element-resize-detector");
 
-    import {bottom, compact, getLayoutItem, moveElement, validateLayout} from './utils';
+    import {bottom, compact, getLayoutItem, moveElement} from './utils';
     //var eventBus = require('./eventBus');
     import GridItem from './GridItem.vue'
 
@@ -117,7 +117,6 @@
         },
         mounted: function() {
             this.$nextTick(function () {
-                validateLayout(this.layout);
                 var self = this;
                 this.$nextTick(function() {
                     if (self.width === null) {

--- a/src/ResponsiveGridLayout.vue
+++ b/src/ResponsiveGridLayout.vue
@@ -12,7 +12,7 @@
 <script>
     var elementResizeDetectorMaker = require("element-resize-detector");
 
-    import {bottom, compact, getLayoutItem, moveElement, validateLayout, findItemInArray, findAndRemove} from './utils';
+    import {bottom, compact, getLayoutItem, moveElement, findItemInArray, findAndRemove} from './utils';
     import {getBreakpointFromWidth, getColsFromBreakpoint, findOrGenerateResponsiveLayout, generateResponsiveLayout} from './responsiveUtils';
     import GridItem from './GridItem.vue'
 
@@ -103,7 +103,6 @@
         },
         mounted() {
             this.$nextTick(function () {
-                validateLayout(this.layout);
                 this.originalCols = this.colNum;
                 var self = this;
                 window.onload = function() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -437,27 +437,23 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
 /**
  * Validate a layout. Throws errors.
  *
- * @param  {Array}  layout        Array of layout items.
+ * @param  {Object}  layout       Layout item.
  * @param  {String} [contextName] Context name for errors.
  * @throw  {Error}                Validation error.
  */
 export function validateLayout(layout: Layout, contextName: string): void {
   contextName = contextName || "Layout";
   const subProps = ['x', 'y', 'w', 'h'];
-  if (!Array.isArray(layout)) throw new Error(contextName + " must be an array!");
-  for (let i = 0, len = layout.length; i < len; i++) {
-    const item = layout[i];
-    for (let j = 0; j < subProps.length; j++) {
-      if (typeof item[subProps[j]] !== 'number') {
-        throw new Error('VueGridLayout: ' + contextName + '[' + i + '].' + subProps[j] + ' must be a number!');
-      }
+  for (let j = 0; j < subProps.length; j++) {
+    if (typeof layout[subProps[j]] !== 'number') {
+      throw new Error('VueGridLayout: ' + contextName + '[' + i + '].' + subProps[j] + ' must be a number!');
     }
-    if (item.i && typeof item.i !== 'string') {
-      throw new Error('VueGridLayout: ' + contextName + '[' + i + '].i must be a string!');
-    }
-    if (item.static !== undefined && typeof item.static !== 'boolean') {
-      throw new Error('VueGridLayout: ' + contextName + '[' + i + '].static must be a boolean!');
-    }
+  }
+  if (layout.i && typeof layout.i !== 'string') {
+    throw new Error('VueGridLayout: ' + contextName + '[' + i + '].i must be a string!');
+  }
+  if (layout.static !== undefined && typeof layout.static !== 'boolean') {
+    throw new Error('VueGridLayout: ' + contextName + '[' + i + '].static must be a boolean!');
   }
 }
 


### PR DESCRIPTION
validateLayout in utils.js now operates on a layout item and is called from GridItem.vue instead of the GridLayout.vue and ResponsiveGridLayout.vue.

This allows the x, y, w, and h to be configured properly in the template and the validation will respect wherever those properties are meant to come from.