### PR TITLE
Upgrade babel to remove DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,21 +28,21 @@
     "interactjs": "https://github.com/taye/interact.js.git#v1.3.0-alpha.4"
   },
   "devDependencies": {
-    "babel-core": "^6.0.0",
-    "babel-loader": "^6.0.0",
-    "babel-preset-es2015": "^6.0.0",
-    "babel-plugin-transform-runtime": "^6.0.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
     "babel-plugin-transform-flow-comments": "^6.7.0",
+    "babel-plugin-transform-runtime": "^6.0.0",
+    "babel-preset-es2015": "^6.0.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-1": "^6.5.0",
     "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
+    "vue": "^2.2.6",
     "vue-loader": "^11.1.4",
     "vue-template-compiler": "^2.2.6",
     "webpack": "^3.5.6",
-    "webpack-dev-server": "^2.7.0",
-    "vue": "^2.2.6"
+    "webpack-dev-server": "^2.7.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Upgrade babel to remove deprecation warning when running in development mode:

```bash
DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```

Reference: https://github.com/babel/babel-loader/pull/391