### PR TITLE
Add webpack HotModuleReplacementPlugin explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "dist/vue-grid-layout.min.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "dist": "webpack --progress --hide-modules --config webpack.build.js && cross-env NODE_ENV=production webpack --progress --hide-modules --config  webpack.build.min.js"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 var path = require('path')
 var webpack = require('webpack')
 
-
 module.exports = {
     entry: './src/main.js',
     output: {
@@ -54,7 +53,10 @@ module.exports = {
     performance: {
         hints: false
     },
-    devtool: '#eval-source-map'
+    devtool: '#eval-source-map',
+    plugins: [
+      new webpack.HotModuleReplacementPlugin()
+    ]
 }
 
 


### PR DESCRIPTION
### Problem
When I run on development environment, `HotModuleReplacementPlugin` seems not working
I fixed by add `HotModuleReplacementPlugin` explicitly