### PR TITLE
Emit dimensions in pixel in resize event

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,8 +442,8 @@ Working example [here](https://jbaysolutions.github.io/vue-grid-layout/examples/
     Every time an item is being resized and changes size
  
 ```javascript
-    resizeEvent: function(i, newH, newW){
-        console.log("RESIZE i=" + i + ", H=" + newH + ", W=" + newW);
+    resizeEvent: function(i, newH, newW, newHPx, newWPx){
+        console.log("RESIZE i=" + i + ", H=" + newH + ", W=" + newW + ", H(px)=" + newHPx + ", W(px)=" + newWPx);
     },
 ``` 
 

--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -522,7 +522,7 @@
                 this.lastH = y;
 
                 if (this.innerW !== pos.w || this.innerH !== pos.h) {
-                    this.$emit("resize", this.i, pos.h, pos.w);
+                    this.$emit("resize", this.i, pos.h, pos.w, newSize.height, newSize.width);
                 }
                 if (event.type === "resizeend" && (this.previousW !== this.innerW || this.previousH !== this.innerH)) {
                     this.$emit("resized", this.i, pos.h, pos.w, newSize.height, newSize.width);


### PR DESCRIPTION
It's often useful to have the dimensions of the placeholder in resize event because it allows us to resize the content when the user is resizing an item in real-time.

