### PR TITLE
release interact instance,and repaire the grid layout self spell mistask

### DIFF
--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -285,6 +285,7 @@
             this.eventBus.$off('setRowHeight', self.setRowHeightHandler);
             this.eventBus.$off('directionchange', self.directionchangeHandler);
             this.eventBus.$off('setColNum', self.setColNum);
+            this.interactObj.unset() // destroy interact intance
         },
         mounted: function () {
             this.cols = this.$parent.colNum;

--- a/src/GridLayout.vue
+++ b/src/GridLayout.vue
@@ -117,9 +117,9 @@
         },
         beforeDestroy: function(){
             //Remove listeners
-            this.eventBus.$off('resizeEvent', self.resizeEventHandler);
-            this.eventBus.$off('dragEvent', self.dragEventHandler);
-            window.removeEventListener("resize", self.onWindowResize)
+            this.eventBus.$off('resizeEvent', this.resizeEventHandler);
+            this.eventBus.$off('dragEvent', this.dragEventHandler);
+            window.removeEventListener("resize", this.onWindowResize)
         },
         mounted: function() {
             this.$nextTick(function () {


### PR DESCRIPTION
the undestory interact instance make the vue-grid-layout memory leak.

every time vue-grid-layout renew,there is a leak.

there is a mistake in beforeDestroy method of gridLayout.vue which make vue-grid-layout still leak.

after repaire this two things.memory leak is stop.