### PR TITLE
Fixed format of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Include the browser-ready bundle (download from [releases](https://github.com/jb
 ``` 
 
 
-````html
+```html
 
     <grid-layout
             :layout.sync="layout"


### PR DESCRIPTION
Thanks for the hard work for this project.

The README looked pretty corrupted so decided to make a PR.

```
The markdown had an extra "`" (back tick) so deleted it.
```

Thank you!

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>