### PR TITLE
Avoid problems with circular reference in object over responsive layout

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -51,7 +51,9 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
     // These can be null
     isDraggable: layoutItem.isDraggable, isResizable: layoutItem.isResizable
   };*/
-    return JSON.parse(JSON.stringify(layoutItem));
+    //return JSON.parse(JSON.stringify(layoutItem));
+    /** avoid problems with circular references in objects **/
+    return Object.assign({}, layoutItem);
 }
 
 /**


### PR DESCRIPTION
This change avoid issues with circular reference in objects. A issue very common working with chartjs.
This is the source.