### PR TITLE
fix: unexpected exception on grid-layout mount

### DIFF
--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -223,7 +223,7 @@
                 });
             },
             layoutUpdate() {
-                if (this.layout !== undefined) {
+                if (this.layout !== undefined && this.originalLayout !== null) {
                     if (this.layout.length !== this.originalLayout.length) {
                         // console.log("### LAYOUT UPDATE!", this.layout.length, this.originalLayout.length);
 


### PR DESCRIPTION
When the `layout` prop changes quickly after the grid-layout gets created, `layoutUpdate` is called before the `originalLayout` property is set, causing an uncaught exception.

To reproduce the issue: https://jsfiddle.net/scfkwzhd/1/ (check the devtools console to see the exception)