### PR TITLE
feat: watchers for min/max height and width

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -354,6 +354,18 @@
                 // console.log("### renderRtl");
                 this.tryMakeResizable();
                 this.createStyle();
+            },
+            minH: function () {
+                this.tryMakeResizable();
+            },
+            maxH: function () {
+                this.tryMakeResizable();
+            },
+            minW: function () {
+                this.tryMakeResizable();
+            },
+            maxW: function () {
+                this.tryMakeResizable();
             }
         },
         computed: {


### PR DESCRIPTION
Hi, thanks for awesome plugin.

I added  watchers for min/max height and width. For a dynamic change restrict size.

Use case:
```vue
     <grid-item
        v-for="item in layout"
        ...
        :minH="item.h === minimizedHeight ? minimizedHeight : minH"
        :maxH="item.h === minimizedHeight ? minimizedHeight : Infinity"
      >
```
![Peek 2019-06-03 11-14](https://user-images.githubusercontent.com/16123366/58787475-8b782f00-85f2-11e9-8d09-10d0248488da.gif)

