### PR TITLE
Fix: no-touch on mobile and only if item is draggable or resizable

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -1,7 +1,7 @@
 <template>
     <div ref="item"
          class="vue-grid-item"
-         :class="{ 'vue-resizable' : resizableAndNotStatic, 'static': static, 'resizing' : isResizing, 'vue-draggable-dragging' : isDragging, 'cssTransforms' : useCssTransforms, 'render-rtl' : renderRtl, 'disable-userselect': isDragging, 'no-touch': isAndroid }"
+         :class="{ 'vue-resizable' : resizableAndNotStatic, 'static': static, 'resizing' : isResizing, 'vue-draggable-dragging' : isDragging, 'cssTransforms' : useCssTransforms, 'render-rtl' : renderRtl, 'disable-userselect': isDragging, 'no-touch': isAndroid && (isDraggable || isResizable) }"
          :style="style"
     >
         <slot></slot>


### PR DESCRIPTION
#110 Disable touch on android but in my project I have a edit mode and view mode, in view mode grid items are not draggable and not resizable, the no-touch disable the scroll when the user touch the grid item.
I added the verification of property isDraggable and isResizable to apply the no-touch