### PR TITLE
Emit @resized whenever pixel width/height changes

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -325,14 +325,17 @@
             },
             rowHeight: function () {
                 this.createStyle();
+                this.emitResized();
             },
             cols: function () {
                 this.tryMakeResizable();
                 this.createStyle();
+                this.emitResized();
             },
             containerWidth: function () {
                 this.tryMakeResizable();
                 this.createStyle();
+                this.emitResized();
             },
             x: function (newVal) {
                 this.innerX = newVal;
@@ -345,10 +348,12 @@
             h: function (newVal) {
                 this.innerH = newVal
                 this.createStyle();
+                this.emitResized();
             },
             w: function (newVal) {
                 this.innerW = newVal;
                 this.createStyle();
+                this.emitResized();
             },
             renderRtl: function () {
                 // console.log("### renderRtl");
@@ -419,7 +424,19 @@
                     }
                 }
                 this.style = style;
-
+            },
+            emitResized() {
+                // this.style has width and height with trailing 'px'. The
+                // resized event is without them
+                let styleProps = {};
+                for (let prop of ['width', 'height']) {
+                    let val = this.style[prop];
+                    let matches = val.match(/^(\d+)px$/);
+                    if (! matches)
+                        return;
+                    styleProps[prop] = matches[1];
+                }
+                this.$emit("resized", this.i, this.h, this.w, styleProps.height, styleProps.width);
             },
             handleResize: function (event) {
                 if (this.static) return;


### PR DESCRIPTION
Until now, `@resized` was only emitted when the user "manually" resized the grid
items. Not if e.g. the user changes the width the window, which causes w and h to stay
the same, but the width in pixels changes.

With this commit, all changes to GridItem-s that cause width and
height to change (in pixles) also cause `@resized` to be emitted.

# About Whether to `$emit('resized'....)` or Some Other Event Name

Here I'm re-using the `@resized` event name, because it is actually an event that occurs when the GridItem resizes in pixels.

But I understand the counter-argument that says: This should be a different event, because it doesn't occur when the _user_ resizes a GridItem (with the mouse) but when the GridItem resize indirectly, e.g. because of a window resize.The [doc for the existing resize event](https://github.com/jbaysolutions/vue-grid-layout#events) is:

> Resize event
>
> Every time an item is being resized and changes size

```javascript
    /**
     * 
     * @param i the item id/index
     * @param newH new height in grid rows 
     * @param newW new width in grid columns
     * @param newHPx new height in pixels
     * @param newWPx new width in pixels
     * 
     */
    resizedEvent: function(i, newH, newW, newHPx, newWPx){
        console.log("RESIZED i=" + i + ", H=" + newH + ", W=" + newW + ", H(px)=" + newHPx + ", W(px)=" + newWPx);
    },
``` 

In my opinion that is ambiguous and could be read either way. And I decided that since `newHPx` and `newWPx` changes, emitting a `@resized` event is appropriate. It does mean that current listeners for the `@resized` event will get events under more circumstances than today, though.

We could also add an extra parameter to the event, e.g. `draggedResize` which is `true` or `false` so event recipients can determine whether the cause was a drag operation or an indirect operation.

If the general consensus is for another event name, I'll change the name of the event. What made me abandon this approach was that I couldn't come up with a better name for the event. 
