### PR TITLE
Fix: MaxRows in GridItems not updated

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -256,6 +256,10 @@
                 self.rowHeight = rowHeight;
             };
 
+            self.setMaxRowsHandler = function (maxRows) {
+                self.maxRows = maxRows;
+            };
+
             self.directionchangeHandler = () => {
                 this.rtl = getDocumentDir() === 'rtl';
                 this.compact();
@@ -270,6 +274,7 @@
             this.eventBus.$on('setDraggable', self.setDraggableHandler);
             this.eventBus.$on('setResizable', self.setResizableHandler);
             this.eventBus.$on('setRowHeight', self.setRowHeightHandler);
+            this.eventBus.$on('setMaxRows', self.setMaxRowsHandler);
             this.eventBus.$on('directionchange', self.directionchangeHandler);
             this.eventBus.$on('setColNum', self.setColNum)
 
@@ -283,6 +288,7 @@
             this.eventBus.$off('setDraggable', self.setDraggableHandler);
             this.eventBus.$off('setResizable', self.setResizableHandler);
             this.eventBus.$off('setRowHeight', self.setRowHeightHandler);
+            this.eventBus.$off('setMaxRows', self.setMaxRowsHandler);
             this.eventBus.$off('directionchange', self.directionchangeHandler);
             this.eventBus.$off('setColNum', self.setColNum);
             this.interactObj.unset() // destroy interact intance

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -206,7 +206,10 @@
                     this.eventBus.$emit("setColNum", this.colNum);
                 }
                 this.onWindowResize();
-            }
+            },
+            maxRows: function() {
+                this.eventBus.$emit("setMaxRows", this.maxRows);
+            },
         },
         methods: {
             layoutUpdate() {


### PR DESCRIPTION
The MaxRows property was not updated in GridItem when the prop was changed in GridLayout. I've added the missing event listener that will propagate the max rows change to every GridItems. 