### PR TITLE
Support initial responsive layouts and breakpoint change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ Include the browser-ready bundle (download from [releases](https://github.com/jb
 
     The value must be an `Array` of `Object` items. Each item must have `i`, `x`, `y`, `w` and `h` properties. Please refer to the documentation for `GridItem` below for more information.
 
+* **responsiveLayouts**
+
+    * type: `Object`
+    * required: `false`
+    * default : `{}`
+
+    This is the initial layouts of the grid per breakpoint if `responsive` is set to `true`.
+    The `Object` keys are breakpoint names and each values is an `Array` of `Object` items as defined by `layout` prop. eg:{ lg:[layout items], md:[layout items] }.
+    If it is set after the layout creation, it replaces the layout configuration in all breakpoints
+
 * **colNum**
     
     * type: `Number`
@@ -469,6 +479,7 @@ Working example [here](https://jbaysolutions.github.io/vue-grid-layout/examples/
             @layout-mounted="layoutMountedEvent"
             @layout-ready="layoutReadyEvent"
             @layout-updated="layoutUpdatedEvent"
+            @breakpoint-changed="breakpointChangedEvent"
     >
 
         <grid-item v-for="item in layout"
@@ -623,6 +634,23 @@ Working example [here](https://jbaysolutions.github.io/vue-grid-layout/examples/
      */
     containerResizedEvent: function(i, newH, newW, newHPx, newWPx){
         console.log("CONTAINER RESIZED i=" + i + ", H=" + newH + ", W=" + newW + ", H(px)=" + newHPx + ", W(px)=" + newWPx);
+    },
+``` 
+
+* **breakpointChangedEvent**
+
+    Breakpoint Changed event
+
+    Every time the breakpoint value changed due to window resize
+ 
+```javascript
+    /**
+     * 
+     * @param newBreakpoint the breakpoint name
+     * 
+     */
+    breakpointChangedEvent: function(newBreakpoint){
+        console.log("BREAKPOINT CHANGED B=" + newBreakpoint);
     },
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Include the browser-ready bundle (download from [releases](https://github.com/jb
     * default : `{}`
 
     This is the initial layouts of the grid per breakpoint if `responsive` is set to `true`.
-    The `Object` keys are breakpoint names and each values is an `Array` of `Object` items as defined by `layout` prop. eg:{ lg:[layout items], md:[layout items] }.
-    If it is set after the layout creation, it replaces the layout configuration in all breakpoints
+    The keys of the `Object` are breakpoint names and each value is an `Array` of `Object` items as defined by `layout` prop. eg:{ lg:[layout items], md:[layout items] }.
+    Setting the prop after the creation of the GridLayout has no effect.
 
 * **colNum**
     
@@ -641,7 +641,7 @@ Working example [here](https://jbaysolutions.github.io/vue-grid-layout/examples/
 
     Breakpoint Changed event
 
-    Every time the breakpoint value changed due to window resize
+    Every time the breakpoint value changes due to window resize
  
 ```javascript
     /**

--- a/README.md
+++ b/README.md
@@ -647,10 +647,11 @@ Working example [here](https://jbaysolutions.github.io/vue-grid-layout/examples/
     /**
      * 
      * @param newBreakpoint the breakpoint name
+     * @param newLayout the chosen layout for the breakpoint
      * 
      */
-    breakpointChangedEvent: function(newBreakpoint){
-        console.log("BREAKPOINT CHANGED B=" + newBreakpoint);
+    breakpointChangedEvent: function(newBreakpoint, newLayout){
+        console.log("BREAKPOINT CHANGED breakpoint=", newBreakpoint, ", layout: ", newLayout );
     },
 ``` 
 

--- a/examples/07-prevent-collision.html
+++ b/examples/07-prevent-collision.html
@@ -13,6 +13,8 @@
     <a href="https://github.com/jbaysolutions/vue-grid-layout">View project on Github</a>
     <br/>
     <a href="06-responsive.html">Previous example: Responsive</a>
+    <br/>
+    <a href="08-responsive-predefined-layouts.html">Next example: Responsive - predefined layouts</a>
 
     <div id="app" style="width: 100%;">
         <!--<pre>{{ $data | json }}</pre>-->

--- a/examples/08-responsive-predefined-layouts.html
+++ b/examples/08-responsive-predefined-layouts.html
@@ -12,9 +12,7 @@
 
     <a href="https://github.com/jbaysolutions/vue-grid-layout">View project on Github</a>
     <br/>
-    <a href="05-mirrored.html">Previous example: Mirrored grid layout</a>
-    <br/>
-    <a href="07-prevent-collision.html">Next example: Prevent collision</a>
+    <a href="07-prevent-collision.html">Previous example: Prevent collision</a>
 
     <div id="app" style="width: 100%;">
         <!--<pre>{{ $data | json }}</pre>-->
@@ -37,6 +35,7 @@
             <input type="checkbox" v-model="responsive"/> Responsive
             <br/>
             <grid-layout :layout.sync="layout"
+                         :responsive-layouts="layouts"
                          :col-num="12"
                          :row-height="30"
                          :is-draggable="draggable"
@@ -44,6 +43,7 @@
                          :vertical-compact="true"
                          :use-css-transforms="true"
                          :responsive="responsive"
+                         @breakpoint-changed="breakpointChangedEvent"
             >
                 <grid-item v-for="item in layout"
                            :x="item.x"
@@ -60,6 +60,6 @@
     </div>
     <script src="vue.min.js"></script>
     <script src="../dist/vue-grid-layout.umd.min.js"></script>
-    <script src="06-responsive.js"></script>
+    <script src="08-responsive-predefined-layouts.js"></script>
 </body>
 </html>

--- a/examples/08-responsive-predefined-layouts.js
+++ b/examples/08-responsive-predefined-layouts.js
@@ -1,0 +1,115 @@
+var testLayouts = {
+    md: [
+        {"x":0, "y":0, "w":2, "h":2, "i":"0"},
+        {"x":2, "y":0, "w":2, "h":4, "i":"1"},
+        {"x":4, "y":0, "w":2, "h":5, "i":"2"},
+        {"x":6, "y":0, "w":2, "h":3, "i":"3"},
+        {"x":2, "y":4, "w":2, "h":3, "i":"4"},
+        {"x":4, "y":5, "w":2, "h":3, "i":"5"},
+        {"x":0, "y":2, "w":2, "h":5, "i":"6"},
+        {"x":2, "y":7, "w":2, "h":5, "i":"7"},
+        {"x":4, "y":8, "w":2, "h":5, "i":"8"},
+        {"x":6, "y":3, "w":2, "h":4, "i":"9"},
+        {"x":0, "y":7, "w":2, "h":4, "i":"10"},
+        {"x":2, "y":19, "w":2, "h":4, "i":"11"},
+        {"x":0, "y":14, "w":2, "h":5, "i":"12"},
+        {"x":2, "y":14, "w":2, "h":5, "i":"13"},
+        {"x":4, "y":13, "w":2, "h":4, "i":"14"},
+        {"x":6, "y":7, "w":2, "h":4, "i":"15"},
+        {"x":0, "y":19, "w":2, "h":5, "i":"16"},
+        {"x":8, "y":0, "w":2, "h":2, "i":"17"},
+        {"x":0, "y":11, "w":2, "h":3, "i":"18"},
+        {"x":2, "y":12, "w":2, "h":2, "i":"19"}
+        ],
+    lg: [
+        {"x":0,"y":0,"w":2,"h":2,"i":"0"},
+        {"x":2,"y":0,"w":2,"h":4,"i":"1"},
+        {"x":4,"y":0,"w":2,"h":5,"i":"2"},
+        {"x":6,"y":0,"w":2,"h":3,"i":"3"},
+        {"x":8,"y":0,"w":2,"h":3,"i":"4"},
+        {"x":10,"y":0,"w":2,"h":3,"i":"5"},
+        {"x":0,"y":5,"w":2,"h":5,"i":"6"},
+        {"x":2,"y":5,"w":2,"h":5,"i":"7"},
+        {"x":4,"y":5,"w":2,"h":5,"i":"8"},
+        {"x":6,"y":4,"w":2,"h":4,"i":"9"},
+        {"x":8,"y":4,"w":2,"h":4,"i":"10"},
+        {"x":10,"y":4,"w":2,"h":4,"i":"11"},
+        {"x":0,"y":10,"w":2,"h":5,"i":"12"},
+        {"x":2,"y":10,"w":2,"h":5,"i":"13"},
+        {"x":4,"y":8,"w":2,"h":4,"i":"14"},
+        {"x":6,"y":8,"w":2,"h":4,"i":"15"},
+        {"x":8,"y":10,"w":2,"h":5,"i":"16"},
+        {"x":10,"y":4,"w":2,"h":2,"i":"17"},
+        {"x":0,"y":9,"w":2,"h":3,"i":"18"},
+        {"x":2,"y":6,"w":2,"h":2,"i":"19"}
+    ],
+};
+
+// var GridLayout = VueGridLayout.GridLayout;
+// var GridItem = VueGridLayout.GridItem;
+
+new Vue({
+    el: '#app',
+    // components: {
+    //     "GridLayout": GridLayout,
+    //     "GridItem": GridItem
+    // },
+    data: {
+        layouts: testLayouts,
+        layout: testLayouts["lg"],
+        draggable: true,
+        resizable: true,
+        responsive: true,
+        index: 0
+    },
+/*
+    mounted: function () {
+        this.index = this.layout.length;
+    },
+    methods: {
+        increaseWidth: function(item) {
+            var width = document.getElementById("content").offsetWidth;
+            width += 20;
+            document.getElementById("content").style.width = width+"px";
+        },
+        decreaseWidth: function(item) {
+
+            var width = document.getElementById("content").offsetWidth;
+            width -= 20;
+            document.getElementById("content").style.width = width+"px";
+        },
+        removeItem: function(item) {
+            //console.log("### REMOVE " + item.i);
+            this.layout.splice(this.layout.indexOf(item), 1);
+        },
+        addItem: function() {
+            var self = this;
+            //console.log("### LENGTH: " + this.layout.length);
+            var item = {"x":0,"y":0,"w":2,"h":2,"i":this.index+"", whatever: "bbb"};
+            this.index++;
+            this.layout.push(item);
+        },
+        breakpointChangedEvent: function(newBreakpoint, newLayout){
+            console.log("BREAKPOINT CHANGED breakpoint=", newBreakpoint, ", layout: ", newLayout );
+        }
+    }
+*/
+});
+
+/*
+function generateLayout() {
+    return _.map(_.range(0, 25), function (item, i) {
+        var y = Math.ceil(Math.random() * 4) + 1;
+        return {
+            x: _.random(0, 5) * 2 % 12,
+            y: Math.floor(i / 6) * y,
+            w: 2,
+            h: y,
+            i: i.toString(),
+            static: Math.random() < 0.05
+        };
+    });
+}*/
+
+
+

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,7 @@
                     @layout-mounted="layoutMountedEvent"
                     @layout-ready="layoutReadyEvent"
                     @layout-updated="layoutUpdatedEvent"
+                    @breakpoint-changed="breakpointChangedEvent"
             >
                 <grid-item v-for="item in layout" :key="item.i"
                            :static="item.static"
@@ -225,6 +226,9 @@
             layoutUpdatedEvent: function(newLayout){
                 console.log("Updated layout: ", newLayout)
             },
+            breakpointChangedEvent: function(newBreakpoint, newLayout){
+                console.log("breakpoint changed breakpoint=", newBreakpoint, ", layout: ", newLayout );
+            }
 
         },
     }

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -413,8 +413,7 @@
                 this.layouts[newBreakpoint] = layout;
 
                 if (this.lastBreakpoint !== newBreakpoint) {
-                    this.$emit('update:')
-                    this.$emit('breakpoint-changed', newBreakpoint)
+                    this.$emit('breakpoint-changed', newBreakpoint, layout);
                 }
 
                 // new prop sync

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -89,6 +89,12 @@
                 type: Boolean,
                 default: false
             },
+            responsiveLayouts: {
+                type: Object,
+                default: function() {
+                    return {};
+                }
+            },
             breakpoints:{
                 type: Object,
                 default: function(){return{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
@@ -215,6 +221,9 @@
                 });
             },
             layout: function () {
+                this.layoutUpdate();
+            },
+            responsiveLayouts: function() {
                 this.layoutUpdate();
             },
             colNum: function (val) {
@@ -403,6 +412,11 @@
                 // Store the new layout.
                 this.layouts[newBreakpoint] = layout;
 
+                if (this.lastBreakpoint !== newBreakpoint) {
+                    this.$emit('update:')
+                    this.$emit('breakpoint-changed', newBreakpoint)
+                }
+
                 // new prop sync
                 this.$emit('update:layout', layout);
 
@@ -413,7 +427,7 @@
             // clear all responsive layouts
             initResponsiveFeatures(){
                 // clear layouts
-                this.layouts = {};
+                this.layouts = Object.assign({}, this.responsiveLayouts);
             },
 
             // find difference in layouts

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -223,9 +223,6 @@
             layout: function () {
                 this.layoutUpdate();
             },
-            responsiveLayouts: function() {
-                this.layoutUpdate();
-            },
             colNum: function (val) {
                 this.eventBus.$emit("setColNum", val);
             },
@@ -390,7 +387,7 @@
 
             // finds or generates new layouts for set breakpoints
             responsiveGridLayout(){
-
+                
                 let newBreakpoint = getBreakpointFromWidth(this.breakpoints, this.width);
                 let newCols = getColsFromBreakpoint(newBreakpoint, this.cols);
 

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -387,7 +387,6 @@
 
             // finds or generates new layouts for set breakpoints
             responsiveGridLayout(){
-                
                 let newBreakpoint = getBreakpointFromWidth(this.breakpoints, this.width);
                 let newCols = getColsFromBreakpoint(newBreakpoint, this.cols);
 


### PR DESCRIPTION
Based on https://github.com/wzquyin/vue-grid-layout, here is a suggestion of a PR that would minimize the changes of the source project. 

This PR adds __responsiveLayouts__ prop which defines the initial layouts for all desired breakpoints. The downside of this implementation is that the user needs to assign the "layout" prop seperately for it to work as expected. 
* Related issue #265 

*Note*: An enhancement would be to update the layout prop in the GridLayout whenever  __responsiveLayouts__ changes. That would be to add a watcher for the prop, which I already tried though it was not working as expected so I left it aside for the moment.

Also added __breakpoint-changed__ event that gets emitted evey time the breakpoint changes. 
* Related issue: #385 

Finally the PR has a minor fixe to a typo in an example file. 