### PR TITLE
Fix error when layout items get removed

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -291,7 +291,9 @@
             this.eventBus.$off('setMaxRows', self.setMaxRowsHandler);
             this.eventBus.$off('directionchange', self.directionchangeHandler);
             this.eventBus.$off('setColNum', self.setColNum);
-            this.interactObj.unset() // destroy interact intance
+            if (this.interactObj) {
+                this.interactObj.unset() // destroy interact intance
+            }
         },
         mounted: function () {
             this.cols = this.$parent.colNum;


### PR DESCRIPTION
When layout items are removed, an error occurs
```
webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:1887 TypeError: Cannot read property 'unset' of undefined
    at VueComponent.beforeDestroy (webpack-internal:///./node_modules/vue-grid-layout/dist/vue-grid-layout.common.js:5563)
    at invokeWithErrorHandling (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:1853)
    at callHook (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:4213)
    at VueComponent.Vue.$destroy (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:3972)
    at destroy (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:3156)
    at invokeDestroyHook (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:6104)
    at removeVnodes (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:6120)
    at updateChildren (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:6225)
    at patchVnode (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:6309)
    at VueComponent.patch [as __patch__] (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:6472)

```

This takes care of the error