### PR TITLE
Change function call order for responsive features

### DIFF
--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -170,9 +170,10 @@
                 this.originalLayout = this.layout;
                 const self = this;
                 this.$nextTick(function() {
+                    self.initResponsiveFeatures();
+                    
                     self.onWindowResize();
 
-                    self.initResponsiveFeatures();
 
                     //self.width = self.$el.offsetWidth;
                     addWindowEventListener('resize', self.onWindowResize);


### PR DESCRIPTION
Problems occur when starting at a window size that is different from the default value.
`self.initResponsiveFeatures();` needs to be called first before `onWindowResize();`
therefore it could assign the layouts as responsiveLayouts.