### PR TITLE
Update Example09DynamicAddRemove.vue

### DIFF
--- a/website/docs/.vuepress/components/Example09DynamicAddRemove.vue
+++ b/website/docs/.vuepress/components/Example09DynamicAddRemove.vue
@@ -26,6 +26,7 @@
                        :w="item.w"
                        :h="item.h"
                        :i="item.i"
+                       :key="item.i"
             >
                 <span class="text">{{item.i}}</span>
                 <span class="remove" @click="removeItem(item.i)">x</span>


### PR DESCRIPTION
fixed module warning when compile
Module Warning (from ./node_modules/vue-loader/lib/loaders/templateLoader.js):
(Emitted value instead of an instance of Error) <grid-item v-for="item in layout">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.