### PR TITLE
doc: GridItem 的 h 属性说明

### DIFF
--- a/website/docs/zh/guide/properties.md
+++ b/website/docs/zh/guide/properties.md
@@ -186,7 +186,10 @@
 * type: `Number`
 * required: `true`
 
-标识栅格元素的初始高度，值为`rowHeight`的倍数。
+标识栅格元素的初始高度，值为`rowHeight`的自然倍数。
+不要使用小数，能正常初始化但同列的其它元素会在拖动时因垂直位移计算不准确而产生错位。
+实际显示高度(showHeight)和`h`、`rowHeight`、`margin`的关系表现为：
+showHeight = (margin[1] + rowHeight) * h - margin[1]; (margin[1] 表示垂直位移)
 
 ### minW
     


### PR DESCRIPTION
描述了实际显示高度和其它属性配置之间的关系
指出 高度系数 h 在使用小数倍数时会出现的问题，并更改其值描述