### PR TITLE
fix: when item ref or his parent is hidden, offsetWidth = 0

### DIFF
--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -315,7 +315,10 @@
             },
             onWindowResize: function () {
                 if (this.$refs !== null && this.$refs.item !== null && this.$refs.item !== undefined) {
-                    this.width = this.$refs.item.offsetWidth;
+		    const width = this.$refs.item.offsetWidth;
+		    if (width > 0) {
+		    	this.width = width;
+		    }
                 }
                 this.eventBus.$emit("resizeEvent");
             },


### PR DESCRIPTION
when item ref or his parent is hidden, offsetWidth = 0, it will happen some bug in old version chrome browser;
![亚信安全20221128-101512](https://user-images.githubusercontent.com/25569373/204177284-d264106d-a655-4250-9c9b-c7ad54844869.jpg)
