### PR TITLE
fix: resolve the wrong actual dragging item which drag from outside

### DIFF
--- a/website/docs/.vuepress/components/Example10DragFromOutside.vue
+++ b/website/docs/.vuepress/components/Example10DragFromOutside.vue
@@ -88,21 +88,20 @@ export default {
                     i: 'drop',
                 });
             }
-            let index = this.layout.findIndex(item => item.i === 'drop');
-            if (index !== -1) {
+            if (this.$refs.gridlayout?.$children.some(el => el.i === 'drop' && !el.$el.classList.contains('vue-grid-placeholder'))) {
+                let el = this.$refs.gridlayout.$children.find(el => el.i === 'drop' && !el.$el.classList.contains('vue-grid-placeholder'))
                 try {
-                    this.$refs.gridlayout.$children[this.layout.length].$refs.item.style.display = "none";
+                    el.$refs.item.style.display = "none";
                 } catch {
                 }
-                let el = this.$refs.gridlayout.$children[index];
                 el.dragging = {"top": mouseXY.y - parentRect.top, "left": mouseXY.x - parentRect.left};
                 let new_pos = el.calcXY(mouseXY.y - parentRect.top, mouseXY.x - parentRect.left);
 
                 if (mouseInGrid === true) {
                     this.$refs.gridlayout.dragEvent('dragstart', 'drop', new_pos.x, new_pos.y, 1, 1);
-                    DragPos.i = String(index);
-                    DragPos.x = this.layout[index].x;
-                    DragPos.y = this.layout[index].y;
+                    DragPos.i = String(this.layout.length - 1);
+                    DragPos.x = new_pos.x;
+                    DragPos.y = new_pos.y;
                 }
                 if (mouseInGrid === false) {
                     this.$refs.gridlayout.dragEvent('dragend', 'drop', new_pos.x, new_pos.y, 1, 1);


### PR DESCRIPTION
### Situation:
When I use the feature of dragging item from outside, I find the dragging item can't place in some specific position.

After researching, I found that the `grid-item` I got by the below codes is another existing `grid-item`.
`let index = this.layout.findIndex(item => item.i === 'drop');`
`let el = this.$refs.gridlayout.$children[index];`
And it leads to the wrong result of `calcXY()` which based on `w` and `h` of the unexpected `grid-item`.

### Root case:
The reason is mismatching between `layout` sort and `$refs.gridlayout.$children` sort. So we may get unexpected `gird-item` by using index of `layout`. 
Refer: https://v2.vuejs.org/v2/api/index.html#vm-children

### Solution:
Instead of `layout`, get `grid-item` by `$refs.gridlayout.$children` directly. Like below: 
`let el = this.$refs.gridlayout.$children.find(el => el.i === 'drop' && !el.$el.classList.contains('vue-grid-placeholder'))`
Ps: `i` of `vue-grid-placeholder` also is 'drop'