### PR TITLE
Remove dragover event listener when component unmounts

### DIFF
--- a/website/docs/.vuepress/components/Example10DragFromOutside.vue
+++ b/website/docs/.vuepress/components/Example10DragFromOutside.vue
@@ -62,15 +62,21 @@ export default {
                 {"x": 4, "y": 5, "w": 2, "h": 5, "i": "8"},
                 {"x": 5, "y": 10, "w": 4, "h": 3, "i": "9"},
             ],
-        }
+
+            controller: new window.AbortController()
+        };
     },
     mounted() {
         document.addEventListener("dragover", function (e) {
             mouseXY.x = e.clientX;
             mouseXY.y = e.clientY;
-        }, false);
+        }, {
+            capture: false,
+            signal: this.controller?.signal
+        });
     },
     beforeDestroy() {
+        this.controller.abort();
     },
     methods: {
         drag: function (e) {


### PR DESCRIPTION
Hi! 👋 
Example10DragFromOutside.vue listens to the dragover events when the component is mounted. But this listener is never removed even after the component unmounts. This can lead to potential memory leaks.

We used memlab to calculate the heap size before and after the fix:
Before fix:
<img width="1728" alt="vgl-bef" src="https://github.com/jbaysolutions/vue-grid-layout/assets/56495631/c5b5cab1-99fe-4451-b4b8-1648e713cc11">


After fix:
<img width="1716" alt="vgl-after" src="https://github.com/jbaysolutions/vue-grid-layout/assets/56495631/641a81b3-b197-47b0-9b17-40a5447ac983">
